### PR TITLE
Sign-in to Azure before running Az CLI commands

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,6 +35,7 @@ env:
 jobs:
   build:
     name: Build
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-20.04
     outputs:
       deployPullRequest: ${{ steps.should_deploy_pr.outputs.deployPullRequest }}
@@ -138,9 +139,9 @@ jobs:
           skip_api_build: true
 
   delete_preview_environment:
+    name: Delete Static Web App Pull Request preview environment
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-20.04
-    name: Delete Static Web App Pull Request preview environment
     steps:
       - name: Set Static Web App deployment token
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -143,6 +143,10 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-20.04
     steps:
+      - name: Sign in to Azure
+        uses: azure/login@v1
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
       - name: Set Static Web App deployment token
         run: |
           jsonDeploymentToken=$(az staticwebapp secrets list --name ${{ env.STATIC_WEB_APP_NAME }} --resource-group ${{ env.RESOURCE_GROUP_NAME }} --query 'properties.apiKey')


### PR DESCRIPTION
- Sign-in to Azure before running Az CLI commands
- Don't run build on PR `closed` event